### PR TITLE
migrate from 'err-derive' to 'thiserror'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intel-pstate"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Jeremy Soller <jackpot51@gmail.com>",
     "Michael Aaron Murphy <michael@system76.com>"
@@ -15,4 +15,4 @@ edition = "2018"
 
 [dependencies]
 smart-default = "0.6.0"
-err-derive = "0.2.4"
+thiserror = "1.0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 //! Crate for fetching and modifying the intel_pstate kernel parameters.
 //!
 //! # Example
@@ -84,7 +86,7 @@ impl PState {
 
     /// Get the minimum performance percent.
     pub fn min_perf_pct(&self) -> Result<u8, PStateError> {
-        parse_file(self.path.join("min_perf_pct")).map_err(|why| PStateError::GetMinPerf(why))
+        parse_file(self.path.join("min_perf_pct")).map_err(PStateError::GetMinPerf)
     }
 
     /// Set the minimum performance percent.
@@ -95,7 +97,7 @@ impl PState {
 
     /// Get the maximum performance percent.
     pub fn max_perf_pct(&self) -> Result<u8, PStateError> {
-        parse_file(self.path.join("max_perf_pct")).map_err(|why| PStateError::GetMaxPerf(why))
+        parse_file(self.path.join("max_perf_pct")).map_err(PStateError::GetMaxPerf)
     }
 
     /// Set the maximum performance percent.
@@ -106,8 +108,8 @@ impl PState {
 
     /// If true, this signifies that turbo is disabled.
     pub fn no_turbo(&self) -> Result<bool, PStateError> {
-        let value = parse_file::<u8, _>(self.path.join("no_turbo"))
-            .map_err(|why| PStateError::GetNoTurbo(why))?;
+        let value =
+            parse_file::<u8, _>(self.path.join("no_turbo")).map_err(PStateError::GetNoTurbo)?;
         Ok(value > 0)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,19 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use std::io;
-//! use intel_pstate::PState;
+//! use intel_pstate::{PState, PStateError};
 //!
-//! fn main() -> io::Result<()> {
-//!     if let Ok(pstate) = PState::new() {
-//!         pstate.set_min_perf_pct(50)?;
-//!         pstate.set_max_perf_pct(100)?;
-//!         pstate.set_no_turbo(false)?;
-//!     }
+//! fn main() -> Result<(), PStateError> {
+//!     let pstate = PState::new()?;
+//!
+//!     pstate.set_min_perf_pct(50)?;
+//!     pstate.set_max_perf_pct(100)?;
+//!     pstate.set_no_turbo(false)?;
 //!
 //!     Ok(())
 //! }
 //! ```
 
-#[macro_use]
-extern crate err_derive;
 #[macro_use]
 extern crate smart_default;
 
@@ -29,22 +26,23 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum PStateError {
-    #[error(display = "failed to get min perf pstate value: {}", _0)]
+    #[error("failed to get min perf pstate value: {0}")]
     GetMinPerf(io::Error),
-    #[error(display = "failed to get max perf pstate value: {}", _0)]
+    #[error("failed to get max perf pstate value: {0}")]
     GetMaxPerf(io::Error),
-    #[error(display = "failed to get no turbo pstate value: {}", _0)]
+    #[error("failed to get no turbo pstate value: {0}")]
     GetNoTurbo(io::Error),
-    #[error(display = "intel_pstate directory not found")]
+    #[error("intel_pstate directory not found")]
     NotFound,
-    #[error(display = "failed to set min perf pstate value to {}: {}", _0, _1)]
+    #[error("failed to set min perf pstate value to {0}: {1}")]
     SetMinPerf(u8, io::Error),
-    #[error(display = "failed to set max perf pstate value to {}: {}", _0, _1)]
+    #[error("failed to set max perf pstate value to {0}: {1}")]
     SetMaxPerf(u8, io::Error),
-    #[error(display = "failed to set no turbo pstate value to {}: {}", _0, _1)]
+    #[error("failed to set no turbo pstate value to {0}: {1}")]
     SetNoTurbo(bool, io::Error),
 }
 
@@ -54,7 +52,7 @@ pub struct PStateValues {
     pub min_perf_pct: u8,
     #[default(100)]
     pub max_perf_pct: u8,
-    pub no_turbo: bool,
+    pub no_turbo:     bool,
 }
 
 impl PStateValues {


### PR DESCRIPTION
this is *possibly* required for using `clap-3` in `pop-os/system76-power` and `pop-os/upgrade`.

see https://github.com/pop-os/system76-power/pull/230#discussion_r617299256

also fixed a doc comment while i was at it